### PR TITLE
Switch /admin/customers.json to /admin/custom_collections.json

### DIFF
--- a/src/resources/custom-collection.php
+++ b/src/resources/custom-collection.php
@@ -65,7 +65,7 @@ return array(
          */
         "createCustomCollection" => array(
             "httpMethod" => "POST",
-            "uri" => "/admin/customers.json",
+            "uri" => "/admin/custom_collections.json",
             "summary" => "Creates a custom collection.",
             "responseModel" => "defaultJsonResponse",
             "parameters" => array(


### PR DESCRIPTION
An incorrect references to /admin/customers.json was corrected to point at /admin/custom_collections.json in the custom collections resource.
