### PR TITLE
Fixed definition for getProductImages.

### DIFF
--- a/src/resources/product-image.php
+++ b/src/resources/product-image.php
@@ -25,14 +25,19 @@ return array(
             "summary" => "Retrieve a list of all Product images.",
             "responseModel" => "defaultJsonResponse",
             "parameters" => array(
+                "id" => array(
+                    "type" => "string",
+                    "location" => "uri",
+                    "description" => "The ID of the Product."
+                ),
                 "since_id" => array(
                     "type" => "number",
-                    "location" => "uri",
+                    "location" => "query",
                     "description" => "Restrict results to after the specified ID."
                 ),
                 "fields" => array(
                     "type" => "integer",
-                    "location" => "uri",
+                    "location" => "query",
                     "description" => "Comma-separated list of fields to include in the response."
                 )
             )


### PR DESCRIPTION
The "id" parameter was missing, resulting in a 404.  This was added using the same definition as getProductMetafields, although I'm not sure that the type should be a string.

While fixing this I also corrected since_id and fields to be included in the query not the uri.
