### PR TITLE
Fix limit and page parameter location for collects.

### DIFF
--- a/src/resources/collect.php
+++ b/src/resources/collect.php
@@ -27,12 +27,12 @@ return array(
             "parameters" => array(
                 "page" => array(
                     "type" => "number",
-                    "location" => "uri",
+                    "location" => "query",
                     "description" => "Page to show (default: 1)."
                 ),
                 "limit" => array(
                     "type" => "number",
-                    "location" => "uri",
+                    "location" => "query",
                     "description" => "Collects per page (default: 50) (maximum: 250)."
                 ),
                 "fields" => array(


### PR DESCRIPTION
The limit and page parameters are passed in the query string.
