### PR TITLE
Uses Guzzle Command's built in default support.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -46,7 +46,7 @@ class Client
      *
      * @var array
      */
-    private $settings;
+    private $settings = [];
     
     
     /**
@@ -135,7 +135,10 @@ class Client
         $this->serviceClient = new GuzzleClient(
                 $client,
                 static::$description,
-                ['emitter' => $this->baseClient->getEmitter()]
+                array(
+                    'emitter'  => $this->baseClient->getEmitter(),
+                    'defaults' => $this->settings,
+                )
             );
     }
     
@@ -235,18 +238,7 @@ class Client
     {
 		if (!$this->serviceClient) $this->buildClient();
 
-		// gather parameters to pass to service definitions
-        $settings = $this->settings;
-
-        // merge client settings/parameters and method parameters
-        $parameters[0] = isset($parameters[0])
-                             ? $parameters[0] + $settings
-                             : $settings;
-          
-        $response = call_user_func_array([$this->serviceClient, $method], $parameters);
-
-		return $response;
-		 
+        return call_user_func_array([$this->serviceClient, $method], $parameters);
     }
     
 }


### PR DESCRIPTION
This uses Guzzle Command's built in support for default parameters [1]
to replace the built in support.

There are two advantages to this

* avoids reinventing the wheel
* ensures that the defaults are only applied to commands and not to
  other methods that are proxied to the command client (e.g. executeAll
  for batch requests).

[1] https://github.com/guzzle/guzzle-services/blob/master/src/GuzzleClient.php#L32