### PR TITLE
Fixes syntax errors in resource definition files.

### DIFF
--- a/src/resources/asset.php
+++ b/src/resources/asset.php
@@ -29,7 +29,7 @@ return array(
                     "type" => "number",
                     "location" => "uri",
                     "required" => true
-                )
+                ),
                 "fields" => array(
                     "type" => "string",
                     "location" => "query",
@@ -55,7 +55,7 @@ return array(
                     "location" => "uri",
                     "description" => "The ID of the theme.",
                     "required" => true
-                )
+                ),
                 "asset[key]" => array(
                     "type" => "string",
                     "location" => "query",

--- a/src/resources/blog.php
+++ b/src/resources/blog.php
@@ -212,6 +212,7 @@ yes: Readers can post comments to blog articles without moderation."
                     "location" => "uri",
                     "description" => "Unique numeric identifier for the blog.",
                     "required" => true
+                )
             )
         )
         

--- a/src/resources/metafield.php
+++ b/src/resources/metafield.php
@@ -326,12 +326,12 @@ return array(
                     "description" => "The ID of the Product.",
                     "required" => true
                 ),
-                "metafield_id" {
+                "metafield_id" => array(
                     "type" => "number",
                     "location" => "uri",
                     "description" => "The ID of the Metafield.",
                     "required" => true
-                }
+                ),
 	            "metafield" => array(
 		            "location" => "json",
 		            "parameters" => array(

--- a/src/resources/product-image.php
+++ b/src/resources/product-image.php
@@ -28,7 +28,7 @@ return array(
                 "id" => array(
                     "type" => "string",
                     "location" => "uri",
-                    "description" => "The ID of the Product."
+                    "description" => "The ID of the Product.",
                     "required" => true
                 ),
                 "since_id" => array(


### PR DESCRIPTION
There were a few syntax errors in the latest updates when I tried to use them.

Getting in to the habit of leaving a trailing comma on the last element of an array makes most of these easier to avoid.