### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ curl -sS https://getcomposer.org/installer | php
 Next, run the Composer command to install the latest stable version of the wrapper:
 
 ```bash
-composer require shopifyextras/shopify-api-wrapper
+composer require shopifyextras/shopify-php-api-wrapper
 ```
 After installing, you need to require Composer's autoloader:
 


### PR DESCRIPTION
The composer installation line was pointing to the incorrect location