### PR TITLE
Make the Guzzle description not be static

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Shopify API Wrapper 
+# Shopify API Wrapper
 By [ShopifyExtras.com](http://www.shopifyextras.com) - 24/7 Shopify Support - Bugs Resolved Same Day
 
 ### Installing via Composer
@@ -34,18 +34,18 @@ $client = Shopify::settings(array(
 
 Then you can begin making requests:
 ```
-// Get a list of all products. 
+// Get a list of all products.
 $client->getProducts();
 
-// Get a list of all orders. 
+// Get a list of all orders.
 $client->getOrders();
 
 // Get a specific product.
-$client->getProduct(array("id", $product_id));
+$client->getProduct(array("id" => $product_id));
 ```
 
 ### Bugs & Issues
-If you spot any bugs, please report it using the issue tracker. If you would like to contribute to the project please feel free to make your amends and submit a pull request. 
+If you spot any bugs, please report it using the issue tracker. If you would like to contribute to the project please feel free to make your amends and submit a pull request.
 
 ### Professional Services
-Unfortunately we are unable to provide free technical support for the wrapper. If you require this kind of help then please contact us by emailing [help@shopifyextras.com](mailto:help@shopifyextras.com). 
+Unfortunately we are unable to provide free technical support for the wrapper. If you require this kind of help then please contact us by emailing [help@shopifyextras.com](mailto:help@shopifyextras.com).

--- a/src/Client.php
+++ b/src/Client.php
@@ -14,7 +14,7 @@ class Client
      *
      * @var \Shopify\Description
      */
-    private static $description;
+    private $description;
     
 	
 	/**
@@ -128,13 +128,13 @@ class Client
     {
         $client = $this->getBaseClient();
        
-        if (!static::$description) {
+        if (!$this->description) {
             $this->reloadDescription();
         }
 
         $this->serviceClient = new GuzzleClient(
                 $client,
-                static::$description,
+                $this->description,
                 array(
                     'emitter'  => $this->baseClient->getEmitter(),
                     'defaults' => $this->settings,
@@ -168,14 +168,14 @@ class Client
     
 
     /**
-     * Description works tricky as a static
+     * Description works tricky as a 
      * property, reload as a needed.
      *
      * @return void
      */
     private function reloadDescription()
     {
-        static::$description = new Description($this->loadConfig());
+        $this->description = new Description($this->loadConfig());
     }
     
     

--- a/src/resources/service-config.php
+++ b/src/resources/service-config.php
@@ -1,6 +1,6 @@
 <?php
 return array(
-	
+
 	/*
     |--------------------------------------------------------------------------
     | Service Name
@@ -9,9 +9,9 @@ return array(
     | Name of the API service these description configs are for.
     |
     */
-    
+
     "name" => "Shopify",
-    
+
     /*
     |--------------------------------------------------------------------------
     | Service Description
@@ -20,9 +20,9 @@ return array(
     | Description of the API service.
     |
     */
-    
+
     "description" => "A Shopify API Wrapper built using Guzzle - ShopifyExtras.com",
-    
+
     /*
     |--------------------------------------------------------------------------
     | Service Configurations
@@ -31,7 +31,7 @@ return array(
     | Configuration files of specfic service descriptions to load.
     |
     */
-    
+
     "services" => array(
         "auth",
         "application-charge",
@@ -63,7 +63,6 @@ return array(
         "recurring-application-charge",
         "redirect",
         "refund",
-        "script-tag",
         "shop",
         "smart-collection",
         "theme",
@@ -71,7 +70,7 @@ return array(
         "user",
         "webhook"
     ),
-    
+
     /*
     |--------------------------------------------------------------------------
     | Default models
@@ -80,7 +79,7 @@ return array(
     | Default response models for typical usage of responses
     |
     */
-    
+
     "models" => array(
         "defaultJsonResponse" => array(
             "type" => "object",


### PR DESCRIPTION
Multiple Shopify Clients can be used at once; I've tested it with a few resources that I'm using and it works great

(I'm using it to try and sync products between 2 Shopify shops)