### PR TITLE
changing bindShared to singleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 composer.lock
 vendor/**
+.idea

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -14,7 +14,7 @@ class ServiceProvider extends LaravelServiceProvider {
 
     public function boot()
     {
-        $configPath = __DIR__ . '../config/config.php';
+        $configPath = __DIR__ . '/../config/config.php';
         if(function_exists('config_path')){
             $publishPath = config_path('shopify.php');
         } else {

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -12,6 +12,17 @@ class ServiceProvider extends LaravelServiceProvider {
      */
     protected $defer = true;
 
+    public function boot()
+    {
+        $configPath = __DIR__ . '../config/config.php';
+        if(function_exists('config_path')){
+            $publishPath = config_path('shopify.php');
+        } else {
+            $publishPath = base_path('config/shopify.php');
+        }
+        $this->publishes([$configPath => $publishPath],'config');
+    }
+
     /**
      * Register the service provider.
      *
@@ -19,6 +30,8 @@ class ServiceProvider extends LaravelServiceProvider {
      */
     public function register()
     {
+        $configPath = __DIR__ . '/../config/config.php';
+        $this->mergeConfigFrom($configPath, 'shopify');
         $this->app->singleton('shopify', function($app) {
 
             if (isset($app['config']['services']['shopify'])) {

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -19,7 +19,7 @@ class ServiceProvider extends LaravelServiceProvider {
      */
     public function register()
     {
-        $this->app->bindShared('shopify', function($app) {
+        $this->app->singleton('shopify', function($app) {
 
             if (isset($app['config']['services']['shopify'])) {
 


### PR DESCRIPTION
With the latest version of laravel you can't use `bindShared()`. It has been changed to `singleton()`